### PR TITLE
fix low-priority/polish todos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -204,3 +204,11 @@ repos:
         entry: uv lock --check
         language: system
         pass_filenames: false
+
+      - id: pyroma
+        name: pyroma
+        description: check packaging best-practices
+        entry: uv run pyroma .
+        language: system
+        pass_filenames: false
+        files: '^pyproject\.toml$'

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -6,8 +6,6 @@ All notable changes to this project will be documented in this file.
 
 - Add codespell as dev-dependency for spellchecking.
 
--
-
 - Drop pylint as linter.
 
 - Drop Python 3.8 support.

--- a/license.md
+++ b/license.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2023 [Libranet.eu](https://libranet.eu).
+Copyright (c) 2023-present [Libranet.eu](https://libranet.eu).
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/src/autoread_dotenv/__init__.py
+++ b/src/autoread_dotenv/__init__.py
@@ -41,9 +41,9 @@ if tp.TYPE_CHECKING:  # pragma: no cover
 try:
     import dotenv
 
-    DOTENV_INSTALLED = 1
+    DOTENV_INSTALLED = True
 except ImportError:  # pragma: no cover
-    DOTENV_INSTALLED = 0
+    DOTENV_INSTALLED = False
 
 from autoread_dotenv.about import (
     authors as __author__,


### PR DESCRIPTION
## Summary
Addresses the "Low priority / polish" section of the packaging review:

- `license.md`: copyright year was frozen at 2023 → changed to "2023-present" instead of a
  numeric range, so it never needs manual bumping again.
- `docs/changes.md`: removed a stray empty `-` bullet under the 1.1.0 heading.
- `src/autoread_dotenv/__init__.py`: `DOTENV_INSTALLED` was an `int` (`1`/`0`) sentinel, only
  ever used via `not DOTENV_INSTALLED` → changed to a plain `bool` for consistency with the rest
  of the typed codebase.
- `.pre-commit-config.yaml`: the `pyroma` dependency-group existed but wasn't wired into
  CI/pre-commit anywhere → added a `pyroma` hook, gated on `pyproject.toml` changes.

## Test plan
- [x] `uv run pre-commit run --all-files` — all hooks pass, including the new `pyroma` hook
      (10/10 rating)
- [x] `uv run pytest` — 13 passed