### PR TITLE
fix release recipe, README wording, tomli fallback, packaging dep, vendored import

### DIFF
--- a/.just/release.justfile
+++ b/.just/release.justfile
@@ -9,7 +9,7 @@ check-package-version: git-tag-list-versions
     # set -euxo pipefail
     set -euo pipefail
 
-    new_version=$(bin/toml get --toml-path pyproject.toml tool.poetry.version)
+    new_version=$(bin/toml get --toml-path pyproject.toml project.version)
     echo -e "\nNew release-version specified in pyproject.toml: $new_version"
 
     # Validate version-syntax
@@ -42,7 +42,7 @@ release: git-check-uncommitted-changes check-package-version
         exit 1
     fi
 
-    new_version=$(bin/toml get --toml-path pyproject.toml tool.poetry.version)
+    new_version=$(bin/toml get --toml-path pyproject.toml project.version)
     printf "\nOK to release ${new_version}? (y/n)\n"
     read answer
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -64,7 +64,7 @@ You can avoid this behaviour by setting `AUTOREAD_ENFORCE_DOTENV=0`.
 [![Python Version](https://img.shields.io/pypi/pyversions/autoread-dotenv?:alt:PyPI-PythonVersion)](https://pypi.org/project/autoread-dotenv/)
 [![PyPI - Implementation](https://img.shields.io/pypi/implementation/autoread-dotenv?:alt:PyPI-Implementation)](https://pypi.org/project/autoread-dotenv/)
 
-`autoread-dotenv` works on Python 3.8+, including PyPy3. Tested until Python 3.14.
+`autoread-dotenv` works on Python 3.9+, including PyPy3. Tested until Python 3.14.
 
 ## Notable dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ docs = [
     "sphinx>=7.1",
     "sphinx-autoapi>=3.3",
     "sphinx-rtd-theme>=3.0",
+    "tomli>=2.0; python_version<\"3.11\"",
 ]
 ipython = [
     # "ipdb>=0.13",
@@ -97,6 +98,8 @@ security = [
     "zizmor>=1.0",
 ]
 testing = [
+    "importlib_metadata>=6.0",  # backport used by tests/test_entrypoints.py on Python <3.10
+    "packaging>=23.0",
     "pytest>=8.3",
     "pytest-clarity>=1.0",
     "pytest-cov>=5.0",

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,5 +1,12 @@
 """Testing of module sitecustomize."""
 
+import sys
+
+if sys.version_info >= (3, 10):  # entry_points(group=...) is stdlib-native from here on
+    from importlib.metadata import entry_points
+else:  # pragma: no cover
+    from importlib_metadata import entry_points
+
 
 def test_import_sitecustomize() -> None:
     try:
@@ -10,6 +17,4 @@ def test_import_sitecustomize() -> None:
 
 
 def test_entrypoint_registration() -> None:
-    from sitecustomize._vendor.importlib_metadata import entry_points
-
     assert "autoread_dotenv" in entry_points(group="sitecustomize").names

--- a/uv.lock
+++ b/uv.lock
@@ -103,9 +103,12 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "codespell" },
+    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "importlib-metadata", version = "9.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "ipython", version = "9.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
     { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pre-commit", version = "4.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pre-commit-hooks" },
@@ -142,6 +145,7 @@ docs = [
     { name = "sphinx-autoapi", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "sphinx-autoapi", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "sphinx-rtd-theme" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 ipython = [
     { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -167,6 +171,9 @@ security = [
     { name = "zizmor", version = "1.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 testing = [
+    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "importlib-metadata", version = "9.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-clarity" },
@@ -187,7 +194,9 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "codespell", specifier = ">=2.4.3" },
+    { name = "importlib-metadata", specifier = ">=6.0" },
     { name = "ipython", specifier = ">=8.12" },
+    { name = "packaging", specifier = ">=23.0" },
     { name = "pre-commit", specifier = ">=3.5" },
     { name = "pre-commit-hooks", specifier = ">=5.0" },
     { name = "prek", specifier = ">=0.2" },
@@ -214,6 +223,7 @@ docs = [
     { name = "sphinx", specifier = ">=7.1" },
     { name = "sphinx-autoapi", specifier = ">=3.3" },
     { name = "sphinx-rtd-theme", specifier = ">=3.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
 ]
 ipython = [
     { name = "ipython", specifier = ">=8.12" },
@@ -229,6 +239,8 @@ pre-commit = [
 ]
 security = [{ name = "zizmor", specifier = ">=1.0" }]
 testing = [
+    { name = "importlib-metadata", specifier = ">=6.0" },
+    { name = "packaging", specifier = ">=23.0" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-clarity", specifier = ">=1.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
@@ -979,6 +991,8 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.11' and python_full_version < '3.15'",
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
@@ -2919,6 +2933,8 @@ name = "zipp"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.11' and python_full_version < '3.15'",
     "python_full_version == '3.10.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }


### PR DESCRIPTION
## Summary
Addresses 5 items from the packaging review (1 high-priority, 4 medium-priority):

- **`.just/release.justfile`** (high): `check-package-version`/`release` still read
  `tool.poetry.version`, a leftover from the poetry-to-uv migration, and failed with
  `error: key 'poetry' not found`. Now reads `project.version`.
- **`docs/readme.md`**: "works on Python 3.8+" → "3.9+", matching `requires-python = ">=3.9"`
  and CHANGELOG 1.1.0 (which both say 3.8 support was dropped).
- **`docs/conf.py`'s `tomli` fallback**: was unusable on Python 3.9/3.10 locally since `tomli`
  wasn't declared anywhere. Added `tomli; python_version<"3.11"` to the `docs` dependency-group.
- **`packaging` dependency**: `tests/test_about.py` and `tests/test_init.py` import
  `packaging.version` directly but relied on it being pulled in transitively via `pytest`.
  Declared explicitly in the `testing` group.
- **`tests/test_entrypoints.py`**: stopped importing the private, underscore-prefixed
  `sitecustomize._vendor.importlib_metadata`. Now uses stdlib `importlib.metadata` on
  Python ≥3.10 and the `importlib_metadata` backport below that (added to `testing`,
  unconditionally rather than marker-gated — `ty` type-checks both branches of the
  `sys.version_info` guard regardless of the active interpreter, so the backport needs to
  resolve in the dev/test venv on every supported Python version).

## Test plan
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] `uv run pytest` — 13 passed
- [x] `just check-package-version` — now correctly reads the version from `project.version`
      (fails only on the pre-existing, out-of-scope dev-version regex check for `1.1.0.dev1`)
- [x] `uv run sphinx-build -b html docs <tmp>` — docs build succeeds