### PR TITLE
fix high-priority todos: about.py fallback + trusted-publishing release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,174 @@
+# Release - Github Actions
+#
+# Builds the package and publishes it to PyPI using OIDC Trusted Publishing (no stored token).
+# Every push to main also publishes to TestPyPI, so packaging breakage is caught before a real
+# release ever happens.
+#
+# Trusted Publishing must be configured on PyPI (and TestPyPI) before this can succeed - see
+# https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+#   - PyPI:     owner=libranet, repo=autoread-dotenv, workflow=release.yaml, environment=release-pypi
+#   - TestPyPI: owner=libranet, repo=autoread-dotenv, workflow=release.yaml, environment=release-test-pypi
+# The two GitHub environments referenced above must also exist under repo Settings > Environments
+# (optionally with protection rules, e.g. required reviewers on release-pypi).
+#
+# Releasing: `just release` tags the version and creates a GitHub Release (`gh release create`),
+# which fires the `release: published` event that triggers the real PyPI publish.
+#
+# Security references:
+#  - https://securitylab.github.com/resources/github-actions-preventing-pwn-requests
+#  - https://securitylab.github.com/resources/github-actions-untrusted-input
+#  - https://securitylab.github.com/resources/github-actions-building-blocks
+#  - https://securitylab.github.com/resources/github-actions-new-patterns-and-mitigations
+#
+# Used actions:
+#   - actions/checkout
+#     repo: https://github.com/actions/checkout
+#     releases: https://github.com/actions/checkout/tags
+#
+#   - extractions/setup-just
+#     repo: https://github.com/extractions/setup-just
+#     releases: https://github.com/extractions/setup-just/releases
+#
+#   - astral-sh/setup-uv: set up uv environment
+#     repo: https://github.com/astral-sh/setup-uv
+#     releases: https://github.com/astral-sh/setup-uv/tags
+#     docs: https://docs.astral.sh/uv/guides/integration/github/
+#
+#   - actions/attest-build-provenance: sign build provenance for supply-chain verification
+#     repo: https://github.com/actions/attest-build-provenance
+#     releases: https://github.com/actions/attest-build-provenance/tags
+#
+#   - actions/upload-artifact + actions/download-artifact: pass the built dist/ between jobs
+#     repo: https://github.com/actions/upload-artifact
+#     releases: https://github.com/actions/upload-artifact/tags
+#     repo: https://github.com/actions/download-artifact
+#     releases: https://github.com/actions/download-artifact/tags
+#
+#   - pypa/gh-action-pypi-publish: publish to PyPI/TestPyPI via OIDC Trusted Publishing
+#     repo: https://github.com/pypa/gh-action-pypi-publish
+#     releases: https://github.com/pypa/gh-action-pypi-publish/tags
+
+
+name: Release
+
+on:
+    push:
+        branches: [main]
+    release:
+        types: [published]
+    workflow_dispatch:
+
+concurrency:
+    # Never cancel an in-progress release/publish mid-flight.
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
+env:
+    # Pin just version for reproducible builds
+    # https://github.com/casey/just/releases
+    JUST_VERSION: "1.56.0"
+
+    # Pin uv version for reproducible builds
+    # https://github.com/astral-sh/uv/releases
+    UV_VERSION: "0.12.3"
+
+permissions: {}
+
+jobs:
+    build:
+        name: Build distribution
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        permissions:
+            id-token: write # required to sign build provenance
+            attestations: write # required to sign build provenance
+        steps:
+
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  persist-credentials: false
+
+            - name: Install pinned version of just
+              uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+              with:
+                  just-version: ${{ env.JUST_VERSION }}
+
+            - name: Install pinned version of uv
+              uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+              with:
+                  version: ${{ env.UV_VERSION }}
+                  # No caching here (unlike linting.yaml/testing.yaml): this workflow builds and
+                  # publishes release artifacts, and a poisoned cache (e.g. from an untrusted PR
+                  # run) must never be reused for a trusted release build.
+                  enable-cache: false
+
+            - name: Build sdist + wheel
+              run: just uv-build
+
+            - name: Sign build provenance
+              uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+              with:
+                  subject-path: "dist/*"
+
+            - name: Upload build artifacts
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: dist
+                  path: dist/
+                  retention-days: 7
+
+    publish-test-pypi:
+        name: Publish in-dev package to test.pypi.org
+        needs: build
+        # Only from main pushes on the upstream repo - never from forks, which don't (and
+        # shouldn't) have Trusted Publishing configured.
+        if: github.repository_owner == 'libranet' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        environment:
+            name: release-test-pypi
+            url: https://test.pypi.org/project/autoread-dotenv/
+        permissions:
+            id-token: write # required for trusted publishing
+        steps:
+
+            - name: Download build artifacts
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+              with:
+                  name: dist
+                  path: dist/
+
+            - name: Publish package to TestPyPI
+              uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+              with:
+                  repository-url: https://test.pypi.org/legacy/
+                  # The version in pyproject.toml is bumped manually, not per-commit, so a
+                  # re-upload of an unchanged version on a later main push must not fail the job.
+                  skip-existing: true
+                  # No attestation for TestPyPI: nothing stops a malicious PyPI from serving a
+                  # signed TestPyPI asset in place of a release intended for the real PyPI.
+                  attestations: false
+
+    publish-pypi:
+        name: Publish released package to pypi.org
+        needs: build
+        if: github.repository_owner == 'libranet' && github.event_name == 'release' && github.event.action == 'published'
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        environment:
+            name: release-pypi
+            url: https://pypi.org/project/autoread-dotenv/
+        permissions:
+            id-token: write # required for trusted publishing
+        steps:
+
+            - name: Download build artifacts
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+              with:
+                  name: dist
+                  path: dist/
+
+            - name: Publish package to PyPI
+              uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+              with:
+                  attestations: true

--- a/.just/release.justfile
+++ b/.just/release.justfile
@@ -27,7 +27,9 @@ check-package-version: git-tag-list-versions
     # echo "new version would be: ${new_version}"
 
 
-# release a new package as git-tag with version specified in pyproject.toml
+# release a new package: tag with the version in pyproject.toml + create a GitHub Release.
+# Publishing to PyPI happens in .github/workflows/release.yaml, triggered by the GitHub Release
+# (event `release: published`) that `gh release create` fires below.
 [group: 'release']
 [unix]
 release: git-check-uncommitted-changes check-package-version
@@ -51,6 +53,9 @@ release: git-check-uncommitted-changes check-package-version
         git push
         git tag ${new_version}
         git push --tags
+
+        echo "Creating GitHub Release ${new_version}"
+        gh release create "${new_version}" --title "${new_version}" --generate-notes
     else
         exit 0
     fi

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -26,6 +26,40 @@ All notable changes to this project will be documented in this file.
 
 - Update `from __future__ import annotations` comments.
 
+- Add `.just/zizmor.justfile` and an active `security` dependency-group to lint GitHub Actions
+  workflows with `zizmor`.
+
+- Wire the `pyroma` dependency-group into `pre-commit` instead of leaving it unused.
+
+- Change `DOTENV_INSTALLED` from an `int` sentinel to a plain `bool`.
+
+- Use `license.md`'s copyright year as "2023-present" so it never needs manual bumping.
+
+- Fix `.just/release.justfile` reading `tool.poetry.version` (a poetry-to-uv leftover) instead of
+  `project.version`.
+
+- Fix `docs/readme.md` still saying "Python 3.8+" instead of "3.9+".
+
+- Fix the unusable `tomli` fallback in `docs/conf.py` by declaring it in the `docs`
+  dependency-group for Python \<3.11.
+
+- Declare `packaging` and `importlib_metadata` explicitly in the `testing` dependency-group
+  instead of relying on them being pulled in transitively.
+
+- Stop importing the private `sitecustomize._vendor.importlib_metadata` in
+  `tests/test_entrypoints.py`; use stdlib `importlib.metadata` (Python >=3.10) or the
+  `importlib_metadata` backport instead.
+
+- Add `uv audit` dependency-vulnerability scanning as a `pre-commit` hook and `just uv-audit`
+  recipe.
+
+- Restore the defensive metadata fallback in `about.py`: `get_metadata_package()` no longer
+  raises `KeyError`/`PackageNotFoundError` at import time, falling back to "unknown" values.
+
+- Add a trusted-publishing release workflow (`.github/workflows/release.yaml`): builds and signs
+  build provenance for the package, publishes every `main` push to TestPyPI, and publishes to
+  PyPI via OIDC Trusted Publishing when a GitHub Release is published.
+
 ## 1.0.4 (2026-01-18)
 
 - Switch from `poetry` to `uv` to manage this package.

--- a/src/autoread_dotenv/about.py
+++ b/src/autoread_dotenv/about.py
@@ -8,12 +8,49 @@ The package must be properly installed in order the metadata to be available.
 from __future__ import annotations  # enables X | Y syntax in annotations for Python <3.10
 
 import importlib.metadata
+import typing as tp
 
 # by default __package__ is str|None
 PACKAGE: str = __package__ or ""
 
-pkginfo: importlib.metadata.PackageMetadata = importlib.metadata.metadata(PACKAGE)
 
-version: str = importlib.metadata.version(PACKAGE)
-license_: str = pkginfo["License-Expression"]
-authors: str = pkginfo["Author-email"]
+class PkgInfo(tp.TypedDict):
+    """Typed subset of a distribution's metadata."""
+
+    author_email: str
+    license: str
+    version: str
+
+
+def get_metadata_package(pkgname: str = "") -> PkgInfo:
+    """Fetch a typed subset of ``pkgname``'s distribution metadata.
+
+    Defaults to this package (``PACKAGE``) when ``pkgname`` is not given.
+    Falls back to "unknown" values when the metadata cannot be found, so that this module -
+    which runs on every Python process start via the ``sitecustomize`` entrypoint - never raises
+    at import time.
+    """
+    if not pkgname:
+        pkgname = PACKAGE
+
+    try:
+        msg = importlib.metadata.metadata(pkgname)
+    except ValueError:  # pragma: no cover
+        # A distribution name is required. __package__ is None/empty.
+        return PkgInfo(author_email="unknown", license="unknown", version="unknown")
+    except importlib.metadata.PackageNotFoundError:  # pragma: no cover
+        # fallback if this package is not properly installed
+        return PkgInfo(author_email="unknown", license="unknown", version="unknown")
+
+    return PkgInfo(
+        author_email=msg.get("Author-email", "unknown"),
+        license=msg.get("License-Expression") or msg.get("License") or "unknown",
+        version=msg.get("Version", "unknown"),
+    )
+
+
+pkginfo: PkgInfo = get_metadata_package()
+
+version: str = pkginfo.get("version", "unknown")
+license_: str = pkginfo.get("license", "unknown")
+authors: str = pkginfo.get("author_email", "unknown")

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -1,5 +1,7 @@
 """Testing of module autoread_dotenv.about."""
 
+import typing as tp
+
 import packaging.version
 
 
@@ -26,11 +28,22 @@ def test_get_metadata_package_unknown_distribution() -> None:
     assert pkginfo == {"author_email": "unknown", "license": "unknown", "version": "unknown"}
 
 
-def test_get_metadata_package_empty_distribution_name(monkeypatch) -> None:
-    """An empty distribution-name (e.g. `__package__` is None) must fall back, not raise."""
-    import autoread_dotenv.about as about_module
+def test_get_metadata_package_value_error(monkeypatch) -> None:
+    """A `ValueError` from `importlib.metadata.metadata()` must fall back, not raise.
 
-    monkeypatch.setattr(about_module, "PACKAGE", "")
-    pkginfo = about_module.get_metadata_package()
+    A `ValueError` is what `importlib.metadata.metadata("")` raises when `__package__` is None -
+    but its behavior for an empty distribution-name is not consistent across Python versions, so
+    `metadata()` itself is mocked here instead, to test the fallback deterministically.
+    """
+    import importlib.metadata
+
+    from autoread_dotenv.about import get_metadata_package
+
+    def raise_value_error(_name) -> tp.NoReturn:
+        msg = "A distribution name is required."
+        raise ValueError(msg)
+
+    monkeypatch.setattr(importlib.metadata, "metadata", raise_value_error)
+    pkginfo = get_metadata_package("autoread-dotenv")
 
     assert pkginfo == {"author_email": "unknown", "license": "unknown", "version": "unknown"}

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -15,3 +15,22 @@ def test_license() -> None:
 
     assert isinstance(license_, str)
     assert license_ == "MIT"
+
+
+def test_get_metadata_package_unknown_distribution() -> None:
+    """A non-installed distribution-name must fall back to "unknown" values, not raise."""
+    from autoread_dotenv.about import get_metadata_package
+
+    pkginfo = get_metadata_package("this-package-does-not-exist")
+
+    assert pkginfo == {"author_email": "unknown", "license": "unknown", "version": "unknown"}
+
+
+def test_get_metadata_package_empty_distribution_name(monkeypatch) -> None:
+    """An empty distribution-name (e.g. `__package__` is None) must fall back, not raise."""
+    import autoread_dotenv.about as about_module
+
+    monkeypatch.setattr(about_module, "PACKAGE", "")
+    pkginfo = about_module.get_metadata_package()
+
+    assert pkginfo == {"author_email": "unknown", "license": "unknown", "version": "unknown"}


### PR DESCRIPTION
## Summary
Addresses the remaining two "High priority" items from the packaging review, plus a changelog
update covering this session's work.

### `about.py` defensive fallback
`pkginfo["License-Expression"]` and `pkginfo["Author-email"]` were raw dict subscripts that could
raise `KeyError` at import time. This module runs on every Python process start via the
`sitecustomize` entrypoint, and a `KeyError` is not caught by `sitecustomize-entrypoints`'s
`ep.load()` guard (it only catches `ModuleNotFoundError`/`AttributeError`).

Restores the pattern from the untracked `_archive/about.py`: `get_metadata_package()` wraps the
metadata lookup, catches `ValueError`/`PackageNotFoundError`, and falls back to `"unknown"` for
each field via `.get(...)` (also falling back from `License-Expression` to the older `License`
field). Module-level unpacking now also uses `.get(..., "unknown")` instead of subscripting.
Added test coverage for both fallback paths, which had none before (100% coverage maintained).

### Trusted-publishing release workflow
Adds `.github/workflows/release.yaml`, modeled on [hynek/stamina's `pypi-package.yml`](https://github.com/hynek/stamina/blob/main/.github/workflows/pypi-package.yml):

- **build**: builds sdist+wheel (`just uv-build`), signs build provenance
  (`actions/attest-build-provenance`), uploads as a workflow artifact. Runs on push to `main`,
  `release: published`, and `workflow_dispatch`.
- **publish-test-pypi**: publishes every `main` push to test.pypi.org (`skip-existing: true`,
  since the version is bumped manually rather than per-commit). Gated to the `libranet` repo only.
- **publish-pypi**: publishes to pypi.org when a GitHub Release is published. Also gated to
  `libranet` only.
- Both publish jobs use PyPI's OIDC Trusted Publishing (`id-token: write`,
  `pypa/gh-action-pypi-publish`) — no stored PyPI token anywhere — each scoped to its own GitHub
  environment (`release-test-pypi`/`release-pypi`).
- No `setup-uv` caching in this workflow (unlike `linting.yaml`/`testing.yaml`): `zizmor` flagged
  cache-poisoning risk for a workflow that builds/publishes real release artifacts.

`.just/release.justfile`'s `release` recipe now also runs `gh release create` after tagging, since
that's what fires the `release: published` event the new workflow listens for.

**Decisions made along the way** (discussed and confirmed):
- Kept the static version field in `pyproject.toml` (no `hatch-vcs`-style dynamic versioning).
- Release trigger is GitHub Release `published`, not a bare tag push.
- Adopted stamina's continuous TestPyPI deploys + build provenance attestations.

**⚠️ Still needed before this can actually publish** (external, can't be done from a workflow file):
- Configure PyPI Trusted Publishing for `owner=libranet, repo=autoread-dotenv,
  workflow=release.yaml, environment=release-pypi` (and the same on test.pypi.org for
  `environment=release-test-pypi`).
- Create the `release-pypi` and `release-test-pypi` environments under repo
  Settings > Environments (optionally with protection rules, e.g. required reviewers on
  `release-pypi`).

### Changelog
`docs/changes.md`: logged everything landed this session under the `1.1.0` heading.

## Test plan
- [x] `uv run pytest --cov=src --cov-report=term-missing` — 15 passed, 100% coverage
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] `just zizmor` — no findings (had to fix a wrong SHA pin and disable `setup-uv` caching)
- [x] `just uv-build` — builds sdist + wheel successfully