### PR TITLE
prepare 1.0.5 release

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 1.1.0 (YYYY-MM-DD)
+## 1.0.5 (2026-08-16)
 
 - Add codespell as dev-dependency for spellchecking.
 
@@ -10,7 +10,12 @@ All notable changes to this project will be documented in this file.
 
 - Drop Python 3.8 support.
 
-- Refactor `SimpleWarning` class to `simple_warning()` context manager function.
+- Fix `TypeError: SimpleWarning.simple_message() takes 1 positional argument but 5 were given`,
+  raised whenever a warning fired inside the `sitecustomize` entrypoint (e.g. a missing `.env`
+  file). `SimpleWarning.simple_message` was assigned directly to `warnings.formatwarning`, which
+  the stdlib calls as `formatwarning(message, category, filename, lineno, line=None)` - up to 5
+  positional arguments, not the 1 `simple_message` accepted. Refactored `SimpleWarning` into the
+  `simple_warning()` context manager, whose `simple_format()` callback matches that signature.
 
 - Move warning utilities from `utils.py` to new `warnings.py` module.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "uv_build"
 
 [project]
 name = "autoread_dotenv"
-version = "1.1.0.dev1"
+version = "1.0.5"
 description = "Automatically set env-vars at the beginning of every python-process in your in-project virtualenv."
 readme = "docs/readme.md"
 authors = [{ name = "Wouter Vanden Hove", email = "wouter@libranet.eu" }]

--- a/uv.lock
+++ b/uv.lock
@@ -86,7 +86,7 @@ wheels = [
 
 [[package]]
 name = "autoread-dotenv"
-version = "1.1.0.dev1"
+version = "1.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -951,8 +951,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version >= '3.11' and python_full_version < '3.15'",
+    "python_full_version >= '3.11'",
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
@@ -2850,8 +2849,7 @@ name = "zipp"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version >= '3.11' and python_full_version < '3.15'",
+    "python_full_version >= '3.11'",
     "python_full_version == '3.10.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }


### PR DESCRIPTION
## Summary
- Finalizes the version: `1.0.5.dev1` -> `1.0.5` (`uv version --bump stable`). The `.dev1` bump
  itself was already sitting uncommitted on `main` from before this PR.
- `docs/changes.md`: sets the 1.0.5 release date, and replaces the vague "Refactor `SimpleWarning`
  class..." bullet with one that documents the actual bug it fixes:

  > `TypeError: SimpleWarning.simple_message() takes 1 positional argument but 5 were given`,
  > raised whenever a warning fired inside the `sitecustomize` entrypoint (e.g. a missing `.env`
  > file).

  Traced via git history: the old `SimpleWarning.simple_message` (a `@staticmethod` taking only
  `message`) was assigned directly to `warnings.formatwarning`, which the stdlib calls as
  `formatwarning(message, category, filename, lineno, line=None)` — up to 5 positional args.
  Already fixed on `main` by the `simple_warning()` context-manager refactor; `test_simple_warning_format`
  already exercises the real `formatwarning()` call signature (4+ positional args), so no code
  change was needed here — just an accurate changelog entry.

## Test plan
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] `uv run pytest --cov=src --cov-report=term-missing` — 15 passed, 100% coverage
- [x] `just check-package-version` — reads `1.0.5`, not yet tagged, valid format

## After merge
Run `just release` from `main` to tag `1.0.5`, create the GitHub Release, and trigger
`.github/workflows/release.yaml`'s `publish-pypi` job — **once PyPI Trusted Publishing is
configured** (see PR #121's description for the exact values needed).