### PR TITLE
chore: post-release housekeeping

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -40,6 +40,15 @@ PRE_COMMIT_HOME='__CWD__/var/cache/pre-commit'
 # https://prek.j178.dev/reference/environment-variables/
 PREK='__CWD__/var/cache/prek'
 
+
+# pytest
+# --numprocesses is capped (not "auto") because "auto" spawns one worker per CPU core, which on
+# this small test suite (currently 15 tests) outnumbers the test items. Workers that receive zero
+# items still initialize coverage and emit a harmless-but-noisy
+# "CoverageWarning: No data was collected" for each one. Bump this if the suite grows past it.
+PYTEST_ADDOPTS='--color=yes --cov=src --cov-report term-missing --numprocesses 4 -v'
+
+
 # temporary-directory
 TMP='__CWD__/var/tmp'
 TMPDIR='__CWD__/var/tmp'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 # the repo. Unless a later match takes precedence,
 # These will be requested for review when someone opens a pull request.
 # *       @WouterVH  # via github-username
-*       wouter@libranet.eu  # via email assocciated with a  github-username
+*       wouter@libranet.eu  # via email associated with a github-username

--- a/.just/release.justfile
+++ b/.just/release.justfile
@@ -1,6 +1,33 @@
 # release
 
 
+# strip a dev-marker before releasing (e.g. 1.0.6.dev1 -> 1.0.6). `check-package-version`'s
+# x.y(.z) regex rejects `.devN` versions, so run this (or `uv version <x.y.z>` for a specific
+# target, e.g. a minor/major bump) before `just release` if pyproject.toml still carries one.
+[group: 'release']
+[unix]
+bump-stable-version:
+    uv version --bump stable
+
+
+# bump pyproject.toml + uv.lock to the next dev-version after a release (e.g. 1.0.5 -> 1.0.6.dev1),
+# and push that as its own commit. Without this, main keeps reporting the just-released version
+# after the tag - indistinguishable from the actual release commit - until someone remembers to
+# bump it by hand. Called automatically at the end of `release`; safe to re-run manually.
+[group: 'release']
+[unix]
+bump-dev-version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    uv version --bump patch --bump dev
+    new_version=$(bin/toml get --toml-path pyproject.toml project.version)
+
+    git add pyproject.toml uv.lock
+    git commit -m "chore: bump version to ${new_version}"
+    git push
+
+
 # check if the new docker-version specified in docker/.gitlab-ci.yml is ok to release
 [group: 'release']
 [unix]
@@ -56,6 +83,9 @@ release: git-check-uncommitted-changes check-package-version
 
         echo "Creating GitHub Release ${new_version}"
         gh release create "${new_version}" --title "${new_version}" --generate-notes
+
+        echo "Bumping main to the next dev-version"
+        just bump-dev-version
     else
         exit 0
     fi

--- a/.just/ty.justfile
+++ b/.just/ty.justfile
@@ -1,7 +1,7 @@
 # ty
 
 
-# show verion of ty
+# show version of ty
 [group: 'ty']
 ty-version:
     @ uv run ty --version

--- a/.just/uv.justfile
+++ b/.just/uv.justfile
@@ -134,8 +134,8 @@ uv-set-python-version version="3.10" *args:
     @ echo -e "Set python version to {{version}}"
 
 
-# bump project version in pyproject.toml
+# bump project version in pyproject.toml, e.g. `just uv-bump-version minor`
 [group: 'uv']
 uv-bump-version value="patch":
-    uv version {{value}}
+    uv version --bump {{value}}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,11 @@ repos:
         entry: uv run check-shebang-scripts-are-executable
         language: system
 
+      - id: codespell
+        name: check spelling
+        entry: uv run codespell
+        language: system
+
       - id: check-json
         name: check json
         entry: uv run check-json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -15,12 +15,12 @@
         // support for hadolint, a Dockerfile linter
         // marketplace: https://marketplace.visualstudio.com/items?itemName=exiasr.hadolint
         // repo: https://github.com/michaellzc/vscode-hadolint
-        "exiasr.hadolint",
+        // "exiasr.hadolint",
 
         // reStructuredText Language Support for Visual Studio Code
         // marketplace: https://marketplace.visualstudio.com/items?itemName=lextudio.restructuredtext
         // repo: https://github.com/vscode-restructuredtext/vscode-restructuredtext
-        "lextudio.restructuredtext",
+        // "lextudio.restructuredtext",
 
         // support for dotenv file syntax
         // marketplace: https://marketplace.visualstudio.com/items?itemName=mikestead.dotenv

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,12 +24,6 @@
         "editor.formatOnSave": false
     },
 
-    // "jupyter.defaultKernel": "${workspaceFolder}/.venv/bin/python",
-    // "jupyter.jupyterServerType": "local",
-
-    "mypy-type-checker.args": ["--config-file", "${workspaceFolder}/pyproject.toml"],
-    "mypy-type-checker.cwd": "${workspaceFolder}/",
-    "mypy-type-checker.importStrategy": "fromEnvironment",
 
     "[python]": {
         "editor.defaultFormatter": "charliermarsh.ruff",
@@ -37,24 +31,22 @@
     },
     "python.envFile": "${workspaceFolder}/.env",
     "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    // the ty extension already defaults this to "None" itself to avoid conflicting with its own
+    // language server, but pin it explicitly so it's reproducible even if Pylance gets installed
+    "python.languageServer": "None",
     "python.terminal.activateEnvironment": true,
+    "python.terminal.useEnvFile": true,
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    "python.testing.pytestArgs": [
-        "--color=yes",
-        "--cov=src",
-        // "--cov-fail-under=90",
-        // "--cov-report xml:${workspaceFolder}/var/coverage/pytest-cobertura.xml",
-        // "--cov-report html:${workspaceFolder}/var/coverage/html",
-        // "--cov-report term-missing",
-        // "--junit-xml=${workspaceFolder}/var/coverage/pytest-junit.xml",
-        // "--pdb",
-        "-v",
-        "${workspaceFolder}/tests/",
-    ],
+    //"python.testing.pytestArgs": [
+    //    "${workspaceFolder}/tests/",
+    //],
     "ruff.configuration": "${workspaceFolder}/pyproject.toml",
-    // "ruff.lint.args": ["--extend-ignore=F401"],
     "ruff.nativeServer": "on",
+
+    // ty.configuration is auto-discovered from [tool.ty] in pyproject.toml, no path needed
+    "ty.importStrategy": "fromEnvironment",
+    "ty.interpreter": "${workspaceFolder}/.venv/bin/python",
 
     "[yaml]": { // per-language config
         "editor.insertSpaces": true,

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Rename `.github/workflows/release.yaml` to `releasing.yaml`.
+
+- Add `pypi` and `test-pypi` entries to `[project.urls]`.
+
+- Fix `docs/security.md`'s "Supported Versions" table listing a `1.1.x` line that was never
+  released; trim the leftover GitHub template text and a grammar typo in the same section.
+
+- Fix typo in `.github/CODEOWNERS`.
+
+- Cap `PYTEST_ADDOPTS`'s `--numprocesses auto` to `--numprocesses 4` in `.env.template`, avoiding
+  noisy `CoverageWarning: No data was collected` from idle pytest-xdist workers on our small test
+  suite.
+
+- Configure the `ty` VS Code extension as the Python language server (`ty.importStrategy`,
+  `ty.interpreter`, `python.languageServer`), replacing the disabled `mypy-type-checker` settings.
+
+- Enable `python.terminal.useEnvFile` so VS Code integrated terminals load `.env`.
+
+- Add `just release`-integrated `bump-dev-version`/`bump-stable-version` recipes so the version is
+  automatically bumped to the next dev-marker after each release, instead of relying on remembering
+  to do it by hand.
+
+- Fix the broken `uv-bump-version` justfile recipe: it ran `uv version {{value}}` (which tries to
+  set the version to the literal string, e.g. `"patch"`) instead of `uv version --bump {{value}}`.
+
+- Bump development version to `1.0.6.dev1`.
+
+- Add a `codespell` pre-commit hook.
+
+- Fix typo in `.just/ty.justfile` comment.
+
 ## 1.0.5 (2026-08-16)
 
 - Add codespell as dev-dependency for spellchecking.

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,12 +2,10 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+Only the latest released version receives security updates.
 
 | Version | Supported |
 | ------- | --------- |
-| 1.1.x   | Yes       |
 | 1.0.x   | Yes       |
 | 0.x     | No        |
 
@@ -15,7 +13,7 @@ currently being supported with security updates.
 
 This project follows a 90 day disclosure timeline.
 
-To report a security issue, please an email <security@libranet.eu> with
+To report a security issue, please send an email to <security@libranet.eu> with
 
 - a description of the issue
 - the steps you took to create the issue,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "uv_build"
 
 [project]
 name = "autoread_dotenv"
-version = "1.0.5"
+version = "1.0.6.dev1"
 description = "Automatically set env-vars at the beginning of every python-process in your in-project virtualenv."
 readme = "docs/readme.md"
 authors = [{ name = "Wouter Vanden Hove", email = "wouter@libranet.eu" }]
@@ -166,7 +166,7 @@ markers = [  # avoid warnings about unregistered markers
 ]
 testpaths = ["tests"]
 pythonpath = ["tests"]  # allows for importing helper-module
-
+addopts = ""
 
 [tool.ruff]
 # https://docs.astral.sh/ruff/configuration/#using-pyprojecttoml

--- a/uv.lock
+++ b/uv.lock
@@ -86,7 +86,7 @@ wheels = [
 
 [[package]]
 name = "autoread-dotenv"
-version = "1.0.5"
+version = "1.0.6.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
Post-release cleanup and small tooling fixes.

- Rename `.github/workflows/release.yaml` to `releasing.yaml`.
- Add `pypi` and `test-pypi` entries to `[project.urls]`.
- Fix `docs/security.md`'s "Supported Versions" table and a typo.
- Fix typo in `.github/CODEOWNERS`.
- Cap `PYTEST_ADDOPTS`'s `--numprocesses auto` to `--numprocesses 4` in `.env.template` to avoid
  noisy `CoverageWarning` from idle pytest-xdist workers.
- Add `just release`-integrated `bump-dev-version`/`bump-stable-version` recipes so the version
  auto-bumps to the next dev-marker after each release.
- Fix the broken `uv-bump-version` justfile recipe (`uv version {{value}}` → `uv version --bump {{value}}`).
- Bump development version to `1.0.6.dev1`.
- Add a `codespell` pre-commit hook.
- Configure the `ty` VS Code extension as the Python language server, replacing disabled
  `mypy-type-checker` settings; enable `python.terminal.useEnvFile`.
- Fix typo in `.just/ty.justfile` comment.

See `docs/changes.md` for the full "Unreleased" list.

## Test plan
- [x] `docs/changes.md` updated