### PR TITLE
Add AUTOREAD_DOTENV_PATH override for non-standard layouts

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -35,6 +35,11 @@ All notable changes to this project will be documented in this file.
 
 - Fix typo in `.just/ty.justfile` comment.
 
+- Add an `AUTOREAD_DOTENV_PATH` environment-variable to override where the `.env`-file is looked
+  up, for setups that don't follow the in-project-virtualenv convention (global installs,
+  containers, editable mounts, ...). Takes precedence over the `sys.prefix`-based discovery. See
+  `docs/readme.md` and the `autoread_dotenv.utils.get_expected_dotenv_path` docstring.
+
 ## 1.0.5 (2026-08-16)
 
 - Add codespell as dev-dependency for spellchecking.

--- a/docs/modules/autoread_dotenv/about/index.rst
+++ b/docs/modules/autoread_dotenv/about/index.rst
@@ -18,10 +18,26 @@ Attributes
 .. autoapisummary::
 
    autoread_dotenv.about.PACKAGE
-   autoread_dotenv.about.msg
-   autoread_dotenv.about.authors
-   autoread_dotenv.about.license_
+   autoread_dotenv.about.pkginfo
    autoread_dotenv.about.version
+   autoread_dotenv.about.license_
+   autoread_dotenv.about.authors
+
+
+Classes
+-------
+
+.. autoapisummary::
+
+   autoread_dotenv.about.PkgInfo
+
+
+Functions
+---------
+
+.. autoapisummary::
+
+   autoread_dotenv.about.get_metadata_package
 
 
 Module Contents
@@ -32,14 +48,45 @@ Module Contents
    :value: ''
 
 
-.. py:data:: msg
+.. py:class:: PkgInfo
 
-.. py:data:: authors
-   :type:  str | list[str]
+   Bases: :py:obj:`TypedDict`
 
-.. py:data:: license_
-   :type:  str | list[str]
+
+   Typed subset of a distribution's metadata.
+
+
+   .. py:attribute:: author_email
+      :type:  str
+
+
+   .. py:attribute:: license
+      :type:  str
+
+
+   .. py:attribute:: version
+      :type:  str
+
+
+.. py:function:: get_metadata_package(pkgname = '')
+
+   Fetch a typed subset of ``pkgname``'s distribution metadata.
+
+   Defaults to this package (``PACKAGE``) when ``pkgname`` is not given.
+   Falls back to "unknown" values when the metadata cannot be found, so that this module -
+   which runs on every Python process start via the ``sitecustomize`` entrypoint - never raises
+   at import time.
+
+
+.. py:data:: pkginfo
+   :type:  PkgInfo
 
 .. py:data:: version
+   :type:  str
+
+.. py:data:: license_
+   :type:  str
+
+.. py:data:: authors
    :type:  str
 

--- a/docs/modules/autoread_dotenv/index.rst
+++ b/docs/modules/autoread_dotenv/index.rst
@@ -34,6 +34,11 @@ autoread_dotenv
          lib64/     -> .venv/lib64/
          pyvenv.cfg -> .venv/pyvenv.cfg
 
+   For layouts that don't follow this convention (global installs, containers, editable
+   mounts, ...), set the ``AUTOREAD_DOTENV_PATH`` environment-variable to the .env-file to
+   use instead - it bypasses sys.prefix-based discovery entirely. See
+   :func:`autoread_dotenv.utils.get_expected_dotenv_path`.
+
 
 
 Submodules
@@ -72,10 +77,10 @@ Package Contents
 ----------------
 
 .. py:data:: __author__
-   :type:  str | list[str]
+   :type:  str
 
 .. py:data:: __license__
-   :type:  str | list[str]
+   :type:  str
 
 .. py:data:: __version__
    :type:  str

--- a/docs/modules/autoread_dotenv/utils/index.rst
+++ b/docs/modules/autoread_dotenv/utils/index.rst
@@ -34,6 +34,19 @@ autoread_dotenv.utils
          lib64/     -> .venv/lib64/
          pyvenv.cfg -> .venv/pyvenv.cfg
 
+   For layouts that don't follow this convention (global installs, containers, editable
+   mounts, ...), set the ``AUTOREAD_DOTENV_PATH`` environment-variable to the .env-file to
+   use instead - it bypasses sys.prefix-based discovery entirely. See
+   :func:`autoread_dotenv.utils.get_expected_dotenv_path`.
+
+
+
+Attributes
+----------
+
+.. autoapisummary::
+
+   autoread_dotenv.utils.AUTOREAD_DOTENV_PATH_VAR
 
 
 Functions
@@ -49,9 +62,22 @@ Functions
 Module Contents
 ---------------
 
+.. py:data:: AUTOREAD_DOTENV_PATH_VAR
+   :type:  str
+   :value: 'AUTOREAD_DOTENV_PATH'
+
+
 .. py:function:: get_expected_dotenv_path()
 
-   Return the expected location of the .env for in-project virtualenvs.
+   Return the expected location of the .env-file.
+
+   Honors the ``AUTOREAD_DOTENV_PATH`` environment-variable when set: it is used verbatim
+   as the path to the .env-file, for setups that don't follow the in-project-virtualenv
+   convention (global installs, containers, editable mounts, ...).
+
+   Otherwise falls back to the in-project-virtualenv convention:
+   sys.prefix is <project-root>/.venv or
+   <project-root> when using toplevel symlinks to .venv
 
 
 .. py:function:: get_dotenv_path()

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -59,6 +59,18 @@ For more information, please see [sitecustomize-entrypoints](http://pypi.python.
 By default, your .env-file read by `autoread-dotenv` will override any pre-existing environment variables.
 You can avoid this behaviour by setting `AUTOREAD_ENFORCE_DOTENV=0`.
 
+## Overriding where the .env-file is looked up
+
+By default, `autoread-dotenv` locates your `.env` relative to `sys.prefix`, assuming the
+in-project-virtualenv layout described above. For setups that don't follow that convention
+(global installs, containers, editable mounts, ...), set `AUTOREAD_DOTENV_PATH` to the full path
+of the `.env`-file to use instead - it takes precedence and skips the `sys.prefix`-based lookup
+entirely:
+
+```bash
+> export AUTOREAD_DOTENV_PATH=/etc/myapp/production.env
+```
+
 ## Compatibility
 
 [![Python Version](https://img.shields.io/pypi/pyversions/autoread-dotenv?:alt:PyPI-PythonVersion)](https://pypi.org/project/autoread-dotenv/)

--- a/src/autoread_dotenv/__init__.py
+++ b/src/autoread_dotenv/__init__.py
@@ -27,6 +27,11 @@ The .env-file must reside in the root of your project-directory.
       lib64/     -> .venv/lib64/
       pyvenv.cfg -> .venv/pyvenv.cfg
 
+For layouts that don't follow this convention (global installs, containers, editable
+mounts, ...), set the ``AUTOREAD_DOTENV_PATH`` environment-variable to the .env-file to
+use instead - it bypasses sys.prefix-based discovery entirely. See
+:func:`autoread_dotenv.utils.get_expected_dotenv_path`.
+
 """
 
 from __future__ import annotations  # enables X | Y syntax in annotations for Python <3.10

--- a/src/autoread_dotenv/utils.py
+++ b/src/autoread_dotenv/utils.py
@@ -27,20 +27,40 @@ The .env-file must reside in the root of your project-directory.
       lib64/     -> .venv/lib64/
       pyvenv.cfg -> .venv/pyvenv.cfg
 
+For layouts that don't follow this convention (global installs, containers, editable
+mounts, ...), set the ``AUTOREAD_DOTENV_PATH`` environment-variable to the .env-file to
+use instead - it bypasses sys.prefix-based discovery entirely. See
+:func:`autoread_dotenv.utils.get_expected_dotenv_path`.
+
 """
 
 from __future__ import annotations
 
+import os
 import pathlib as pl
 import sys
 
+#: Escape hatch for layouts where sys.prefix does not resolve to the project-root
+#: (global installs, containers, editable mounts, ...). When set, it points directly
+#: at the .env file to use, bypassing the sys.prefix-based discovery below entirely.
+AUTOREAD_DOTENV_PATH_VAR: str = "AUTOREAD_DOTENV_PATH"
+
 
 def get_expected_dotenv_path() -> pl.Path:
-    """Return the expected location of the .env for in-project virtualenvs.
+    """Return the expected location of the .env-file.
 
+    Honors the ``AUTOREAD_DOTENV_PATH`` environment-variable when set: it is used verbatim
+    as the path to the .env-file, for setups that don't follow the in-project-virtualenv
+    convention (global installs, containers, editable mounts, ...).
+
+    Otherwise falls back to the in-project-virtualenv convention:
     sys.prefix is <project-root>/.venv or
     <project-root> when using toplevel symlinks to .venv
     """
+    override = os.getenv(AUTOREAD_DOTENV_PATH_VAR)
+    if override:
+        return pl.Path(override)
+
     prefix: pl.Path = pl.Path(sys.prefix)
     base_dir: pl.Path = prefix.parent if prefix.name == ".venv" else prefix
     return base_dir / ".env"

--- a/tests/test_autoread.py
+++ b/tests/test_autoread.py
@@ -82,3 +82,54 @@ def test_get_dotenv_path_returns_none(tmp_path: pl.Path, monkeypatch) -> None:
 
     result = get_dotenv_path()
     assert result is None
+
+
+def test_autoread_dotenv_path_override(tmp_path: pl.Path, monkeypatch) -> None:
+    """AUTOREAD_DOTENV_PATH must take precedence over sys.prefix-based discovery."""
+    from autoread_dotenv import get_dotenv_path, get_expected_dotenv_path
+
+    # sys.prefix resolves to a project-root with its own (different) .env
+    fake_venv = tmp_path / "project" / ".venv"
+    fake_venv.mkdir(parents=True)
+    (tmp_path / "project" / ".env").write_text("FOO=from-sys-prefix\n")
+    monkeypatch.setattr("sys.prefix", str(fake_venv))
+
+    # the override points elsewhere entirely
+    override_file = tmp_path / "elsewhere" / "custom.env"
+    override_file.parent.mkdir()
+    override_file.write_text("FOO=from-override\n")
+    monkeypatch.setenv("AUTOREAD_DOTENV_PATH", str(override_file))
+
+    assert get_expected_dotenv_path() == override_file
+    assert get_dotenv_path() == override_file
+
+
+def test_autoread_dotenv_path_override_missing_file(tmp_path: pl.Path, monkeypatch) -> None:
+    """A set-but-nonexistent AUTOREAD_DOTENV_PATH still overrides sys.prefix discovery.
+
+    get_dotenv_path() reports None (no valid .env found) rather than silently falling back
+    to the sys.prefix-based .env, since the override was explicit.
+    """
+    from autoread_dotenv import get_dotenv_path
+
+    fake_venv = tmp_path / "project" / ".venv"
+    fake_venv.mkdir(parents=True)
+    (tmp_path / "project" / ".env").write_text("FOO=from-sys-prefix\n")
+    monkeypatch.setattr("sys.prefix", str(fake_venv))
+
+    monkeypatch.setenv("AUTOREAD_DOTENV_PATH", str(tmp_path / "does-not-exist.env"))
+
+    assert get_dotenv_path() is None
+
+
+def test_autoread_dotenv_path_override_entrypoint(tmp_path: pl.Path, monkeypatch) -> None:
+    """entrypoint() actually loads env-vars from the AUTOREAD_DOTENV_PATH override."""
+    from autoread_dotenv import entrypoint
+
+    override_file = tmp_path / "custom.env"
+    override_file.write_text("FOO=from-override\n")
+    monkeypatch.setenv("AUTOREAD_DOTENV_PATH", str(override_file))
+    monkeypatch.delenv("FOO", raising=False)
+
+    entrypoint()
+    assert os.getenv("FOO") == "from-override"


### PR DESCRIPTION
## Summary

`autoread-dotenv` locates the `.env` file relative to `sys.prefix`, assuming the documented
in-project-virtualenv convention (`<project-root>/.venv`). That breaks down for layouts that
don't follow it: global installs, containers, editable mounts, etc.

This adds an escape hatch: when the `AUTOREAD_DOTENV_PATH` environment-variable is set,
`get_expected_dotenv_path()` uses it verbatim as the `.env` path and skips `sys.prefix`-based
discovery entirely.

## Changes

- `src/autoread_dotenv/utils.py`: `get_expected_dotenv_path()` checks `AUTOREAD_DOTENV_PATH`
  first, falls back to the existing convention when unset. `entrypoint()` needed no changes -
  it already routes through this function.
- Docs: module docstrings (`__init__.py`/`utils.py`), `docs/readme.md` (new "Overriding where
  the .env-file is looked up" section), `docs/changes.md`.
- Regenerated the autoapi-generated docs (`just sphinx-docs`); this also picked up unrelated
  staleness in `about/index.rst` left over from the earlier `PkgInfo` refactor.
- Tests (`tests/test_autoread.py`, +3): override wins over a valid `sys.prefix`-resolved
  `.env`, override-but-missing-file still reports `None` (no silent fallback), and an
  end-to-end `entrypoint()` check.

## Testing

- `pytest`: 18 passed, 100% coverage (>= 90% required)
- `ruff check .`: clean
- `ty check`: clean
- `sphinx-build`: clean, no warnings