### PR TITLE
Guard entrypoint() against OSError from an unreadable .env

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -40,6 +40,13 @@ All notable changes to this project will be documented in this file.
   containers, editable mounts, ...). Takes precedence over the `sys.prefix`-based discovery. See
   `docs/readme.md` and the `autoread_dotenv.utils.get_expected_dotenv_path` docstring.
 
+- Fix `entrypoint()` crashing every Python process in the venv when `.env` exists but can't be
+  read (e.g. permission-denied): `dotenv.load_dotenv(...)` now catches `OSError` and warns via
+  `simple_warning()`, consistent with the other failure paths in that function. Also fixed the
+  existing "django-dotenv installed instead of python-dotenv" warning to go through
+  `simple_warning()` too (it previously bypassed it), and cleaned up a stray-whitespace bug in
+  that message's line-continuation.
+
 ## 1.0.5 (2026-08-16)
 
 - Add codespell as dev-dependency for spellchecking.

--- a/src/autoread_dotenv/__init__.py
+++ b/src/autoread_dotenv/__init__.py
@@ -88,8 +88,14 @@ def entrypoint() -> None:
     try:
         dotenv.load_dotenv(dotenv_file, override=enforce_dotenv, interpolate=True, verbose=True)
     except AttributeError:  # pragma: no cover
-        stdlib_warnings.warn(
-            "Module 'dotenv.load_dotenv' not found. \
-                This occurs when django-dotenv was installed while we depend on python-dotenv.",
-            stacklevel=2,
-        )
+        with simple_warning():
+            stdlib_warnings.warn(
+                "Module 'dotenv.load_dotenv' not found. "
+                "This occurs when django-dotenv was installed while we depend on python-dotenv.",
+                stacklevel=2,
+            )
+    except OSError as exc:
+        # e.g. a permission-denied .env: get_dotenv_path() only checked is_file(), not
+        # readability. Warn instead of letting this crash every process in the venv.
+        with simple_warning():
+            stdlib_warnings.warn(f"Could not read {dotenv_file}: {exc}", stacklevel=2)

--- a/tests/test_autoread.py
+++ b/tests/test_autoread.py
@@ -2,6 +2,8 @@
 
 import os
 import pathlib as pl
+import sys
+import warnings
 
 import pytest
 
@@ -133,3 +135,26 @@ def test_autoread_dotenv_path_override_entrypoint(tmp_path: pl.Path, monkeypatch
 
     entrypoint()
     assert os.getenv("FOO") == "from-override"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="chmod-based permission-denial isn't reliable on Windows")
+def test_autoread_dotenv_unreadable_file_warns(tmp_path: pl.Path, monkeypatch) -> None:
+    """An unreadable .env (passes is_file(), fails to open) warns instead of crashing."""
+    from autoread_dotenv import entrypoint
+
+    unreadable_file = tmp_path / "unreadable.env"
+    unreadable_file.write_text("FOO=foo\n")
+    unreadable_file.chmod(0o000)
+    monkeypatch.setenv("AUTOREAD_DOTENV_PATH", str(unreadable_file))
+    monkeypatch.delenv("FOO", raising=False)
+
+    try:
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            entrypoint()  # must not raise
+
+        assert os.getenv("FOO") is None  # nothing was loaded
+        assert len(warning_list) == 1
+        assert "Could not read" in str(warning_list[-1].message)
+    finally:
+        unreadable_file.chmod(0o644)


### PR DESCRIPTION
## Summary

`get_dotenv_path()` only checks `is_file()` before `entrypoint()` hands the path to
`dotenv.load_dotenv()`. A permission-denied (or otherwise unreadable) `.env` passes that
check but fails to open, and the resulting `OSError` was previously uncaught - it
propagates out of `entrypoint()` and crashes every Python process started in the venv,
including recovery commands like `pip`/`uv`.

## Changes

- `src/autoread_dotenv/__init__.py`: added an `except OSError as exc:` branch around
  `dotenv.load_dotenv(...)` that warns via `simple_warning()` instead of crashing.
- While in there: fixed the existing "django-dotenv installed instead of python-dotenv"
  `AttributeError` branch to also go through `simple_warning()` (it bypassed it before,
  inconsistent with the other two failure paths in the function), and cleaned up a
  stray-whitespace bug from a line-continuation in that message.
- `docs/changes.md`: logged under `## Unreleased`.
- `tests/test_autoread.py`: new `chmod(0o000)`-based test asserting `entrypoint()` warns
  instead of raising, and that nothing gets loaded into `os.environ`. Skipped on Windows,
  where permission-denial via `chmod` isn't reliable.

## Testing

- `pytest`: 19 passed, 100% coverage (>= 90% required) - the new `OSError` branch is
  genuinely exercised, not `pragma: no cover`d.
- `ruff check .`: clean
- `ty check`: clean