### PR TITLE
Add subprocess-based integration test for the sitecustomize hook

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -47,6 +47,16 @@ All notable changes to this project will be documented in this file.
   `simple_warning()` too (it previously bypassed it), and cleaned up a stray-whitespace bug in
   that message's line-continuation.
 
+- Add a real subprocess-based integration test (`test_entrypoint_fires_in_subprocess` in
+  `tests/test_entrypoints.py`): spawns `sys.executable` as a genuine child process and asserts
+  the sitecustomize hook actually fires and populates its `os.environ`, using
+  `AUTOREAD_DOTENV_PATH` to point it at a throwaway `.env`. The rest of the test-suite only
+  exercises the logic in-process (`monkeypatch.setattr("sys.prefix", ...)` + calling
+  `entrypoint()` directly), which can't catch the hook failing to fire across a real process
+  boundary (e.g. an editable install silently missing entry-point metadata). Paired with a
+  `python -S` sanity-check (`test_entrypoint_does_not_fire_with_python_dash_s`) confirming the
+  first test is actually driven by the sitecustomize hook and not some other leak.
+
 ## 1.0.5 (2026-08-16)
 
 - Add codespell as dev-dependency for spellchecking.

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,5 +1,8 @@
 """Testing of module sitecustomize."""
 
+import os
+import pathlib as pl
+import subprocess
 import sys
 
 if sys.version_info >= (3, 10):  # entry_points(group=...) is stdlib-native from here on
@@ -18,3 +21,64 @@ def test_import_sitecustomize() -> None:
 
 def test_entrypoint_registration() -> None:
     assert "autoread_dotenv" in entry_points(group="sitecustomize").names
+
+
+def test_entrypoint_fires_in_subprocess(tmp_path: pl.Path) -> None:
+    """The sitecustomize hook actually fires in a real child process.
+
+    Every other test in this test-suite exercises the logic in-process: it monkeypatches
+    sys.prefix and calls entrypoint() directly. That proves the logic is correct, but not
+    that Python actually discovers and runs it via the sitecustomize entrypoint at
+    interpreter start-up - the one thing unit tests can't catch (for example an editable
+    install silently missing entry-point metadata, or sitecustomize-entrypoints failing to
+    wire itself into site.py).
+
+    We spawn sys.executable itself as the subprocess: it is a real interpreter that has
+    autoread_dotenv installed with a registered "sitecustomize" entrypoint (see
+    test_entrypoint_registration above), so a plain `python -c ...` invocation is enough to
+    prove the whole chain fires end-to-end - no throwaway venv needs to be built for this.
+    AUTOREAD_DOTENV_PATH (see test_autoread.py) points the child directly at a throwaway
+    .env, independent of whatever sys.prefix resolves to for that interpreter.
+    """
+    dotenv_file = tmp_path / "subprocess.env"
+    dotenv_file.write_text("SUBPROCESS_TEST_VAR=hello-from-subprocess\n")
+
+    env = os.environ.copy()
+    env["AUTOREAD_DOTENV_PATH"] = str(dotenv_file)
+    env.pop("SUBPROCESS_TEST_VAR", None)
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import os; print(os.environ.get('SUBPROCESS_TEST_VAR', ''))"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+
+    assert result.stdout.strip() == "hello-from-subprocess"
+
+
+def test_entrypoint_does_not_fire_with_python_dash_s(tmp_path: pl.Path) -> None:
+    """Sanity-check for the test above: python -S skips site.py (and therefore sitecustomize).
+
+    Confirms the previous test's assertion is actually driven by the sitecustomize hook, not
+    by e.g. AUTOREAD_DOTENV_PATH leaking into the child through some other mechanism.
+    """
+    dotenv_file = tmp_path / "subprocess.env"
+    dotenv_file.write_text("SUBPROCESS_TEST_VAR=hello-from-subprocess\n")
+
+    env = os.environ.copy()
+    env["AUTOREAD_DOTENV_PATH"] = str(dotenv_file)
+    env.pop("SUBPROCESS_TEST_VAR", None)
+
+    result = subprocess.run(
+        [sys.executable, "-S", "-c", "import os; print(os.environ.get('SUBPROCESS_TEST_VAR', ''))"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+
+    assert result.stdout.strip() == ""


### PR DESCRIPTION
## Summary

Every existing test exercises the `entrypoint()` logic in-process: monkeypatch
`sys.prefix`, call `entrypoint()` directly. That proves the logic is correct but not
that Python actually *discovers and runs it* via the sitecustomize entrypoint at
interpreter start-up - the one thing unit tests structurally can't catch (e.g. an
editable install silently missing entry-point metadata, or `sitecustomize-entrypoints`
failing to wire itself into `site.py`).

## Changes

`tests/test_entrypoints.py`:

- `test_entrypoint_fires_in_subprocess`: spawns `sys.executable` itself as a real child
  process - it already has `autoread_dotenv` installed with the `sitecustomize`
  entrypoint registered (see the existing `test_entrypoint_registration`), so no
  throwaway venv needs to be built for this - and points it at a throwaway `.env` via
  `AUTOREAD_DOTENV_PATH` (independent of whatever `sys.prefix` resolves to for that
  interpreter). Asserts the child's `os.environ` actually picked up the value.
- `test_entrypoint_does_not_fire_with_python_dash_s`: sanity-check pairing the test
  above, using `python -S` (skips `site.py`, and therefore `sitecustomize`) to confirm
  the first test's assertion is genuinely driven by the sitecustomize hook and not some
  other leak.
- `docs/changes.md`: logged under `## Unreleased`.

## Testing

- `pytest`: 21 passed, 100% coverage (>= 90% required)
- `ruff check .`: clean
- `ty check`: clean