### PR TITLE
Add Python 3.15 (rc1) to the CI matrices

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -61,6 +61,7 @@ jobs:
                 os:
                     - ubuntu-latest
                 python-version:
+                    - "3.15"
                     - "3.14"
                     - "3.13"
                     - "3.12"

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -61,6 +61,7 @@ jobs:
                 os:
                     - ubuntu-latest
                 python-version:
+                    - "3.15"
                     - "3.14"
                     - "3.13"
                     - "3.12"

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -57,6 +57,11 @@ All notable changes to this project will be documented in this file.
   `python -S` sanity-check (`test_entrypoint_does_not_fire_with_python_dash_s`) confirming the
   first test is actually driven by the sitecustomize hook and not some other leak.
 
+- Add Python 3.15 (currently at rc1) to the `testing.yaml` CI matrix, ahead of the stable
+  release. Verified locally first: `uv python install "3.15"` resolves to `3.15.0rc1` (there is
+  no stable 3.15 release yet, so `uv` treats the rc as the match), and the full test-suite
+  passes against it unmodified.
+
 ## 1.0.5 (2026-08-16)
 
 - Add codespell as dev-dependency for spellchecking.


### PR DESCRIPTION
## Summary

Python 3.15rc1 is out. Adds `"3.15"` to both the `testing.yaml` and `linting.yaml`
matrices, ahead of the stable release.

Verified locally first (not just assumed):

- `uv python install "3.15"` resolves to `3.15.0rc1` - there's no stable 3.15 release yet,
  so `uv` treats the rc as the match for the bare `"3.15"` version string (same format
  already used for every other matrix entry).
- Ran the full test-suite against that interpreter in an isolated venv (not the project's
  own `.venv`, to avoid clobbering it): all 21 tests pass, unmodified, no compatibility
  code needed.

Per discussion, this is a normal matrix entry (no `continue-on-error`) - a regression on
the rc fails the workflow run just like any other Python version would.

## Testing

- `pytest`: 21 passed, 100% coverage (>= 90% required), against both 3.14 (project venv)
  and 3.15.0rc1 (isolated venv)
- `ruff check .`: clean
- `ty check`: clean