### PR TITLE
Fix PermissionError crash in get_dotenv_path() and silent typos in str_to_bool()

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Fix `get_dotenv_path()` crashing on Python < 3.12 when `is_file()` itself raises
+  `PermissionError` (e.g. an unreadable parent directory) instead of reporting "not found" the
+  way it does on 3.12+. It now optimistically returns the path and lets `load_dotenv()`
+  downstream report the real, more specific error.
+
+- Make `str_to_bool()` warn on unrecognized values (e.g. `AUTOREAD_ENFORCE_DOTENV=fasle`) instead
+  of silently treating them the same as `false`.
+
 - Rename `.github/workflows/release.yaml` to `releasing.yaml`.
 
 - Add `pypi` and `test-pypi` entries to `[project.urls]`.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Remove stale `# pragma: no cover` markers on `get_metadata_package()`'s `ValueError`/
+  `PackageNotFoundError` fallbacks in `about.py`. Both branches are already exercised by
+  `tests/test_about.py` and hit 100% coverage on their own; the pragmas were just masking
+  that fact, making it look like these import-time safety nets were trusted rather than
+  tested.
+
 - Fix `get_dotenv_path()` crashing on Python < 3.12 when `is_file()` itself raises
   `PermissionError` (e.g. an unreadable parent directory) instead of reporting "not found" the
   way it does on 3.12+. It now optimistically returns the path and lets `load_dotenv()`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,8 +126,8 @@ test-pypi = "https://test.pypi.org/project/autoread-dotenv/"
 
 
 [tool.codespell]
-ignore-words-list = "hove,astroid"
-skip = "uv.lock"
+ignore-words-list = "fasle, hove"
+skip = "uv.lock, var"
 
 
 [tool.coverage.html]

--- a/src/autoread_dotenv/about.py
+++ b/src/autoread_dotenv/about.py
@@ -35,10 +35,10 @@ def get_metadata_package(pkgname: str = "") -> PkgInfo:
 
     try:
         msg = importlib.metadata.metadata(pkgname)
-    except ValueError:  # pragma: no cover
+    except ValueError:
         # A distribution name is required. __package__ is None/empty.
         return PkgInfo(author_email="unknown", license="unknown", version="unknown")
-    except importlib.metadata.PackageNotFoundError:  # pragma: no cover
+    except importlib.metadata.PackageNotFoundError:
         # fallback if this package is not properly installed
         return PkgInfo(author_email="unknown", license="unknown", version="unknown")
 

--- a/src/autoread_dotenv/utils.py
+++ b/src/autoread_dotenv/utils.py
@@ -39,11 +39,18 @@ from __future__ import annotations
 import os
 import pathlib as pl
 import sys
+import warnings as stdlib_warnings
+
+from autoread_dotenv.warnings import simple_warning
 
 #: Escape hatch for layouts where sys.prefix does not resolve to the project-root
 #: (global installs, containers, editable mounts, ...). When set, it points directly
 #: at the .env file to use, bypassing the sys.prefix-based discovery below entirely.
 AUTOREAD_DOTENV_PATH_VAR: str = "AUTOREAD_DOTENV_PATH"
+
+#: Recognized spellings for str_to_bool(), case-insensitive.
+_TRUE_VALUES: frozenset[str] = frozenset({"1", "true", "yes"})
+_FALSE_VALUES: frozenset[str] = frozenset({"0", "false", "no", ""})
 
 
 def get_expected_dotenv_path() -> pl.Path:
@@ -69,14 +76,37 @@ def get_expected_dotenv_path() -> pl.Path:
 def get_dotenv_path() -> pl.Path | None:
     """Return the location of the .env for in-project virtualenvs.
 
-    Return None if the .env-file does not exist.
+    Return None if the .env-file does not exist. If we can't even tell - e.g. a
+    permission-denied parent directory raises from is_file() itself, on Python < 3.12
+    where pathlib doesn't swallow that OSError the way it swallows "not found" - assume
+    optimistically that it does, and let the load_dotenv() call downstream fail loudly
+    with its own, more specific permission error instead of us wrongly reporting here
+    that the file doesn't exist.
     """
     dotenv_file = get_expected_dotenv_path()
-    if dotenv_file.is_file():
+    try:
+        exists = dotenv_file.is_file()
+    except OSError:
         return dotenv_file
-    return None
+    return dotenv_file if exists else None
 
 
 def str_to_bool(value: str) -> bool:
-    """Convert a string value to a boolean."""
-    return value.lower() in {"1", "true", "yes"}
+    """Convert a string value to a boolean.
+
+    "1"/"true"/"yes" (case-insensitive) are true; "0"/"false"/"no"/"" are false. Anything
+    else is treated as false too, but warns first: an unrecognized value is more likely a
+    typo (e.g. AUTOREAD_ENFORCE_DOTENV=fasle) than an intentional one, and silently
+    falling back to false would be indistinguishable from setting it on purpose.
+    """
+    lowered = value.lower()
+    if lowered in _TRUE_VALUES:
+        return True
+    if lowered not in _FALSE_VALUES:
+        with simple_warning():
+            stdlib_warnings.warn(
+                f"Unrecognized boolean value {value!r}, treating it as false. "
+                "Use '1'/'true'/'yes' for true, or '0'/'false'/'no'/'' for false.",
+                stacklevel=2,
+            )
+    return False

--- a/tests/test_autoread.py
+++ b/tests/test_autoread.py
@@ -158,3 +158,45 @@ def test_autoread_dotenv_unreadable_file_warns(tmp_path: pl.Path, monkeypatch) -
         assert "Could not read" in str(warning_list[-1].message)
     finally:
         unreadable_file.chmod(0o644)
+
+
+def test_get_dotenv_path_permission_error_on_stat(monkeypatch) -> None:
+    """A PermissionError raised by is_file() itself must not crash get_dotenv_path().
+
+    Pathlib does this on Python < 3.12 for an unreadable parent directory, unlike the
+    "file just doesn't exist" case. get_dotenv_path() should optimistically return the
+    path and let load_dotenv() downstream report the real, more specific error instead.
+    """
+    from autoread_dotenv import get_dotenv_path, get_expected_dotenv_path
+
+    def raise_permission_error(_self: pl.Path) -> bool:
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(pl.Path, "is_file", raise_permission_error)
+
+    assert get_dotenv_path() == get_expected_dotenv_path()
+
+
+def test_str_to_bool_warns_on_unrecognized_value() -> None:
+    """A typo like "fasle" must warn instead of silently behaving like "false"."""
+    from autoread_dotenv import str_to_bool
+
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+        result = str_to_bool("fasle")
+
+    assert result is False
+    assert len(warning_list) == 1
+    assert "Unrecognized boolean value" in str(warning_list[-1].message)
+
+
+@pytest.mark.parametrize("value", ["1", "true", "Yes", "0", "false", "No", ""])
+def test_str_to_bool_recognized_values_do_not_warn(value: str) -> None:
+    """None of the documented true/false spellings should trigger the typo-warning."""
+    from autoread_dotenv import str_to_bool
+
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+        str_to_bool(value)
+
+    assert len(warning_list) == 0


### PR DESCRIPTION
## Summary

Two review findings, both confirmed with reproduction:

- **`get_dotenv_path()` crash on Python < 3.12**: it only checked `is_file()`, which on
  Python < 3.12 raises `PermissionError` (instead of returning `False`, as it does on
  3.12+) when an intermediate directory isn't readable. That call happens outside the
  existing `try/except OSError` in `entrypoint()`, so it would crash every Python process
  using the sitecustomize hook. Reproduced directly on Python 3.11.
- **`str_to_bool()` silently swallows typos**: any unrecognized string (`"fasle"`,
  `"garbage"`, ...) fell through to `False`, indistinguishable from an intentional
  `AUTOREAD_ENFORCE_DOTENV=false`.

## Changes

- `get_dotenv_path()` now catches `OSError` around the `is_file()` check and
  optimistically returns the path, letting the existing `load_dotenv()` error handler in
  `entrypoint()` report the real, more specific error instead of masking it as "file does
  not exist."
- `str_to_bool()` now warns (via the existing `simple_warning()` fail-soft idiom, not
  raising) when a value matches neither the recognized true nor false spellings, while
  still returning `False` for it.
- Added regression tests for both, plus a `docs/changes.md` entry.

## Testing

- `uv run pytest tests/` — 28 passed, 100% coverage
- `just ruff-check` — clean
- `just ty-check` — clean
- Manually reproduced the `PermissionError` crash on Python 3.11 before the fix, confirmed
  fixed after