### PR TITLE
CI: apply Linux-only sitecustomize guard to linting.yaml, drop dead comment

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -102,7 +102,10 @@ jobs:
               cache-dependency-glob: "uv.lock"
               prune-cache: true
 
-        - name: Remove sitecustomize.py
+        - name: Remove global sitecustomize.py
+          # Ubuntu-only: unblocks our own sitecustomize entrypoint from the one preinstalled on
+          # the runner image. Nothing equivalent exists to remove on windows-latest.
+          if: runner.os == 'Linux'
           run: just ubuntu-remove-global-sitecustomize
 
         - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -127,17 +127,6 @@ jobs:
               PYTHON_VERSION: ${{ matrix.python-version }}
           run: uv python install "${PYTHON_VERSION}"
 
-        # TEMPORARY: diagnosing "error: justfile does not contain recipe `uv-set-python-version`"
-        # on windows-latest - .just/uv.justfile isn't being imported there for some reason. This
-        # dumps what just actually sees before the real steps run, to find out why. Remove once
-        # root-caused.
-        - name: Debug - list just recipes
-          run: |
-              just --version
-              just --list --unsorted
-              echo "--- .just/uv.justfile file(1) ---"
-              file .just/uv.justfile || true
-
         - name: Remove global sitecustomize.py
           # Ubuntu-only: unblocks our own sitecustomize entrypoint from the one preinstalled on
           # the runner image. Nothing equivalent exists to remove on windows-latest.

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -109,11 +109,6 @@ jobs:
               python-version: ${{ matrix.python-version }}
               version: ${{ env.UV_VERSION }}
 
-        # - name: Remove sitecustomize.py
-        #   run: |
-        #       sudo rm -f /usr/lib/python3.*/sitecustomize.py
-        #       sudo rm -f /etc/python3.*/sitecustomize.py
-
         - name: Set up Python ${{ matrix.python-version }}
           env:
               PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -55,6 +55,12 @@ jobs:
         name: python
         runs-on: ${{ matrix.os }}
         timeout-minutes: 10
+        defaults:
+            run:
+                # Force bash everywhere (incl. windows-latest, which ships Git Bash) so the
+                # ${VAR}-style shell steps below behave identically across the matrix instead of
+                # falling back to pwsh's incompatible syntax on Windows.
+                shell: bash
         strategy:
             fail-fast: false
             matrix:
@@ -68,6 +74,13 @@ jobs:
                     - "3.11"
                     - "3.10"
                     - "3.9"
+                include:
+                    # Exercise the Windows-specific code paths at least once per run - e.g. the
+                    # permission-error handling in autoread_dotenv.utils, whose chmod-based test is
+                    # skipped under sys.platform == "win32" on other OSes - matching the
+                    # "Operating System :: Microsoft :: Windows" classifier in pyproject.toml.
+                    - os: windows-latest
+                      python-version: "3.14"
 
         steps:
 
@@ -114,11 +127,16 @@ jobs:
               PYTHON_VERSION: ${{ matrix.python-version }}
           run: uv python install "${PYTHON_VERSION}"
 
+        - name: Remove global sitecustomize.py
+          # Ubuntu-only: unblocks our own sitecustomize entrypoint from the one preinstalled on
+          # the runner image. Nothing equivalent exists to remove on windows-latest.
+          if: runner.os == 'Linux'
+          run: just ubuntu-remove-global-sitecustomize
+
         - name: Install project + dependencies
           env:
               PYTHON_VERSION: ${{ matrix.python-version }}
           run: |
-              just ubuntu-remove-global-sitecustomize
               just uv-set-python-version "${PYTHON_VERSION}"
               just install
 

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -127,6 +127,17 @@ jobs:
               PYTHON_VERSION: ${{ matrix.python-version }}
           run: uv python install "${PYTHON_VERSION}"
 
+        # TEMPORARY: diagnosing "error: justfile does not contain recipe `uv-set-python-version`"
+        # on windows-latest - .just/uv.justfile isn't being imported there for some reason. This
+        # dumps what just actually sees before the real steps run, to find out why. Remove once
+        # root-caused.
+        - name: Debug - list just recipes
+          run: |
+              just --version
+              just --list --unsorted
+              echo "--- .just/uv.justfile file(1) ---"
+              file .just/uv.justfile || true
+
         - name: Remove global sitecustomize.py
           # Ubuntu-only: unblocks our own sitecustomize entrypoint from the one preinstalled on
           # the runner image. Nothing equivalent exists to remove on windows-latest.

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@
 # but include .env.template
 !.env.template
 
+# 'uv pip install' creates a lockfile
+/.lock
+
 # excluded generated python-files Byte-compiled / optimized / DLL files
 __pycache__/
 

--- a/.just/uv.justfile
+++ b/.just/uv.justfile
@@ -133,9 +133,34 @@ uv-set-python-version version="3.10" *args:
     @ echo "{{version}}" > .python-version
     @ echo -e "Set python version to {{version}}"
 
+# set python-version in .python-version file
+[group: 'uv']
+[windows]
+uv-set-python-version version="3.10" *args:
+    #!pwsh.exe
+    Move-Item .python-version .python-version.backup -Force
+    Set-Content -Path .python-version -Value "{{version}}"
+    Write-Host "Set python version to {{version}}"
+
 
 # bump project version in pyproject.toml, e.g. `just uv-bump-version minor`
 [group: 'uv']
 uv-bump-version value="patch":
     uv version --bump {{value}}
+
+
+
+
+# Fail if pyproject.toml has local [tool.uv.sources] overrides (path/editable deps)
+[group: 'uv']
+check-empty-tool-uv-sources:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    sources=$(toml get 'tool.uv.sources' --toml-path pyproject.toml)
+    if [ "$sources" != "{}" ]; then
+        echo "error: pyproject.toml has [tool.uv.sources] entries — do not commit" >&2
+        # echo "$sources" >&2
+        exit 1
+    fi
+    echo "pyproject.toml is clean (no [tool.uv.sources] overrides)"
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Add a `windows-latest` job (Python 3.14) to the `testing.yaml` CI matrix. The
+  `Operating System :: Microsoft :: Windows` classifier was previously unbacked by any CI
+  run: only `ubuntu-latest` was tested, and the one permission-related test that differs on
+  Windows (`test_autoread_dotenv_unreadable_file_warns`) is `skipif`'d there, so that path
+  was untested on the platform it'd differ from most. Gates the ubuntu-only
+  `ubuntu-remove-global-sitecustomize` step behind `runner.os == 'Linux'` and forces `bash`
+  as the default shell so the existing `${VAR}`-style steps work identically on Windows'
+  Git Bash instead of falling back to incompatible pwsh syntax.
+
 - Remove stale `# pragma: no cover` markers on `get_metadata_package()`'s `ValueError`/
   `PackageNotFoundError` fallbacks in `about.py`. Both branches are already exercised by
   `tests/test_about.py` and hit 100% coverage on their own; the pragmas were just masking

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Fix `just install` failing on Windows with `error: justfile does not contain recipe 'uv-set-python-version'`: the recipe was tagged `[unix]`-only with no `[windows]`
+  counterpart, unlike its siblings (`create-dirs`, `symlink-venv-dirs`,
+  `dotenv-install-from-template`, `dotenv-set-basedir`), which already had both. Added the
+  missing `[windows]` variant (PowerShell `Move-Item`/`Set-Content`). Found by the new
+  `windows-latest` CI job below actually failing on it.
+
 - Add a `windows-latest` job (Python 3.14) to the `testing.yaml` CI matrix. The
   `Operating System :: Microsoft :: Windows` classifier was previously unbacked by any CI
   run: only `ubuntu-latest` was tested, and the one permission-related test that differs on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "uv_build"
 
 
 [project]
-name = "autoread_dotenv"
+name = "autoread-dotenv"
 version = "1.0.6.dev1"
 description = "Automatically set env-vars at the beginning of every python-process in your in-project virtualenv."
 readme = "docs/readme.md"
@@ -36,6 +36,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Summary

Small follow-up to #129 (the `windows-latest` CI job).

- `linting.yaml`'s "Remove sitecustomize.py" step runs `sudo rm -f ...`, which is Ubuntu-only.
  It's now gated behind `if: runner.os == 'Linux'` and renamed to match `testing.yaml`'s step,
  for consistency - even though `linting.yaml` doesn't run a Windows job itself yet.
- `testing.yaml`: removed the commented-out duplicate "Remove sitecustomize.py" block, dead
  since the live, guarded step was added right below it.

## Testing

- YAML parses cleanly for both workflows
- `zizmor` (pedantic persona): no findings